### PR TITLE
Bugfix: ponderi custom din csv

### DIFF
--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -55,7 +55,7 @@ class Portfolio:
                             return False
                     if len(row[Portfolio.COL_WEIGHT].strip()) > 0:
                         try:
-                            s.price = float(row[Portfolio.COL_WEIGHT].strip())
+                            s.weight = float(row[Portfolio.COL_WEIGHT].strip())
                         except ValueError:
                             logging.error(f"Coloana '{Portfolio.COL_WEIGHT}' trebuie sa contina numere reale(separatorul este '.'). Valoarea '{row[Portfolio.COL_WEIGHT]}' este invalida.")
                             return False


### PR DESCRIPTION
Atunci cand folosesti ponderi custom in portofoliu.csv nu functioneaza scriptul.

```ERROR Ponderea nu a fost setata pentru simbolul AQ```

Am atasat csv-ul care replica problema.

[portofoliu.csv](https://github.com/cypryoprisa/replicare-bet-bvb/files/13946929/portofoliu.csv)